### PR TITLE
Add type defs.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Registry } from "@ember/service";
+import { Registry } from '@ember/service';
 
 /**
  * Decorator that wraps `Ember.inject.service`
@@ -10,15 +10,14 @@ import { Registry } from "@ember/service";
  * import { service } from 'ember-decorators/service';
  *
  * export default class StoreInjectedComponent extends Component
- *   @service() store;
+ *   @service store;
  * }
  * ```
  *
  * @function
  * @param {String} [serviceName] - The name of the service to inject. If not provided, the property name will be used
  */
-export function service(): PropertyDecorator;
-
+export function service(target: any, key: any): any;
 /**
  * Decorator that wraps `Ember.inject.service`
  *
@@ -29,13 +28,29 @@ export function service(): PropertyDecorator;
  * import { service } from 'ember-decorators/service';
  *
  * export default class StoreInjectedComponent extends Component
- *   @service() store;
+ *   @service store;
  * }
  * ```
  *
  * @function
  * @param {String} [serviceName] - The name of the service to inject. If not provided, the property name will be used
  */
-export function service<K extends keyof Registry>(
-  serviceName: K
-): PropertyDecorator;
+export function service(target: any, key: any, descriptor: PropertyDescriptor): PropertyDescriptor;
+/**
+ * Decorator that wraps `Ember.inject.service`
+ *
+ * Injects a service into the object as the decorated property
+ *
+ *  ```javascript
+ * import Component from '@ember/component';
+ * import { service } from 'ember-decorators/service';
+ *
+ * export default class StoreInjectedComponent extends Component
+ *   @service store;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [serviceName] - The name of the service to inject. If not provided, the property name will be used
+ */
+export function service<K extends keyof Registry>(serviceName: K): PropertyDecorator;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+import { Registry } from "@ember/service";
+
+/**
+ * Decorator that wraps `Ember.inject.service`
+ *
+ * Injects a service into the object as the decorated property
+ *
+ *  ```javascript
+ * import Component from '@ember/component';
+ * import { service } from 'ember-decorators/service';
+ *
+ * export default class StoreInjectedComponent extends Component
+ *   @service() store;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [serviceName] - The name of the service to inject. If not provided, the property name will be used
+ */
+export function service(): PropertyDecorator;
+
+/**
+ * Decorator that wraps `Ember.inject.service`
+ *
+ * Injects a service into the object as the decorated property
+ *
+ *  ```javascript
+ * import Component from '@ember/component';
+ * import { service } from 'ember-decorators/service';
+ *
+ * export default class StoreInjectedComponent extends Component
+ *   @service() store;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [serviceName] - The name of the service to inject. If not provided, the property name will be used
+ */
+export function service<K extends keyof Registry>(
+  serviceName: K
+): PropertyDecorator;


### PR DESCRIPTION
As with the Ember Data and controller decorator type defs, I've intentionally duplicated the docs so they show up correctly for both overloads in e.g. VS Code.

This does *not* support calling it as `@service foo` and I've yet to figure out an invocation that *does* support both that *and* the longer `@service('foo') fooService`. One option is to only support the callable version from TS's perspective:

```ts
@service() foo: Foo;
@service('foo') fooService: Foo;
```

I'm currently inclined slightly that way b/c it seems to me that supporting the second of those forms *is* important.